### PR TITLE
Added deallocate playbook example to dealocate based on ssid

### DIFF
--- a/duffy-deallocate.yml
+++ b/duffy-deallocate.yml
@@ -1,0 +1,8 @@
+---
+- hosts: localhost
+  gather_facts: False
+  tasks:
+  - name: "teardown nodes from ssid"
+    duffy:
+      state: "absent"
+      ssid: "{{ ssid }}"


### PR DESCRIPTION
Added duffy-deallocate.yml for convenient teardown of duffy nodes.
example usage:
ansible-playbook duffy-deallocate.yml -e"ssid='****'"